### PR TITLE
Fix W4 build warnings due to mismatched types and sign mismatch, and infinite for loop

### DIFF
--- a/src/midiCIProcessor.cpp
+++ b/src/midiCIProcessor.cpp
@@ -107,9 +107,9 @@ void midiCIProcessor::processMIDICI(uint8_t s7Byte){
                                 {buffer[5], buffer[6]},
                                 {buffer[7], buffer[8],
                                  buffer[9], buffer[10]},
-                                intTemp[0],
+                                (uint8_t) intTemp[0],
                                 intTemp[1],
-                                intTemp[2]
+                                (uint8_t) intTemp[2]
                                 //intTemp[3],
                                // &(buffer[11])
                         );
@@ -122,10 +122,10 @@ void midiCIProcessor::processMIDICI(uint8_t s7Byte){
                                 {buffer[5], buffer[6]},
                                 {buffer[7], buffer[8],
                                  buffer[9], buffer[10]},
-                                intTemp[0],
+                                (uint8_t) intTemp[0],
                                 intTemp[1],
-                                intTemp[2],
-                                intTemp[3]
+                                (uint8_t) intTemp[2],
+                                (uint8_t) intTemp[3]
                                 //&(buffer[11])
                         );
                     }
@@ -172,7 +172,7 @@ void midiCIProcessor::processMIDICI(uint8_t s7Byte){
 
                 if (complete) {
                     recvEndPointInfoReply(midici,
-                                     intTemp[0],
+                                     (uint8_t) intTemp[0],
                                      intTemp[1],
                                      buffer
                                      );
@@ -223,9 +223,9 @@ void midiCIProcessor::processMIDICI(uint8_t s7Byte){
                         recvNAK(
 
                             midici,
-                            intTemp[0],
-                            intTemp[1],
-                            intTemp[2],
+                            (uint8_t) intTemp[0],
+                            (uint8_t) intTemp[1],
+                            (uint8_t) intTemp[2],
                             ackNakDetails,
                             intTemp[3],
                             buffer
@@ -235,9 +235,9 @@ void midiCIProcessor::processMIDICI(uint8_t s7Byte){
                         recvACK(
 
                             midici,
-                            intTemp[0],
-                            intTemp[1],
-                            intTemp[2],
+                            (uint8_t) intTemp[0],
+                            (uint8_t) intTemp[1],
+                            (uint8_t) intTemp[2],
                             ackNakDetails,
                             intTemp[3],
                             buffer
@@ -329,7 +329,7 @@ void midiCIProcessor::processProtocolSysex(uint8_t s7Byte){
                     uint8_t protocol[5] = {buffer[0], buffer[1],
                                            buffer[2], buffer[3],
                                            buffer[4]};
-                    recvProtocolAvailable(midici, intTemp[0], protocol);
+                    recvProtocolAvailable(midici, (uint8_t) intTemp[0], protocol);
                 }
             }
             if(midici.ciVer > 1){
@@ -340,7 +340,7 @@ void midiCIProcessor::processProtocolSysex(uint8_t s7Byte){
 //                    uint8_t protocol[5] = {buffer[0], buffer[1],
 //                                           buffer[2], buffer[3],
 //                                           buffer[4]};
-                    if (recvSetProtocolConfirm != nullptr)recvSetProtocolConfirm(midici, intTemp[0]);
+                    if (recvSetProtocolConfirm != nullptr)recvSetProtocolConfirm(midici, (uint8_t) intTemp[0]);
                 }
             }
             break;
@@ -356,7 +356,7 @@ void midiCIProcessor::processProtocolSysex(uint8_t s7Byte){
             }
             if (sysexPos == 18 && recvSetProtocol != nullptr){
                 uint8_t protocol[5] = {buffer[0], buffer[1], buffer[2], buffer[3], buffer[4]};
-                recvSetProtocol(midici, intTemp[0], protocol);
+                recvSetProtocol(midici, (uint8_t) intTemp[0], protocol);
             }
             break;
 
@@ -373,7 +373,7 @@ void midiCIProcessor::processProtocolSysex(uint8_t s7Byte){
                 }
             }
             if (sysexPos == 61 && recvProtocolTest != nullptr){
-                recvProtocolTest(midici, intTemp[0], !!(intTemp[1]));
+                recvProtocolTest(midici, (uint8_t) intTemp[0], !!(intTemp[1]));
             }
 
 
@@ -384,7 +384,7 @@ void midiCIProcessor::processProtocolSysex(uint8_t s7Byte){
             if (sysexPos == 13 ) {
                 intTemp[0] = s7Byte;
                 if (recvSetProtocolConfirm != nullptr){
-                    recvSetProtocolConfirm(midici, intTemp[0]);
+                    recvSetProtocolConfirm(midici, (uint8_t) intTemp[0]);
                 }
             }
             break;

--- a/src/umpMessageCreate.cpp
+++ b/src/umpMessageCreate.cpp
@@ -218,14 +218,14 @@ std::array<uint32_t, 2> UMPMessage::mt4ProgramChange(uint8_t group, uint8_t chan
 
 std::array<uint32_t, 4> UMPMessage::mtFMidiEndpoint(uint8_t filter){
     std::array<uint32_t, 4> umpMess  = {0,0,0,0};
-	umpMess[0] = (0xF << 28) + (UMP_VER_MAJOR << 8) +  UMP_VER_MINOR;
+	umpMess[0] = (uint32_t) ((0xF << 28) + (UMP_VER_MAJOR << 8) +  UMP_VER_MINOR);
     umpMess[1] = filter;
 	return umpMess;
 }
 
 std::array<uint32_t, 4> UMPMessage::mtFMidiEndpointInfoNotify(uint8_t numOfFuncBlock, bool m2, bool m1, bool rxjr, bool txjr){
     std::array<uint32_t, 4> umpMess = {0,0,0,0};
-    umpMess[0] = (0xF << 28) + (MIDIENDPOINT_INFO_NOTIFICATION << 16) + (UMP_VER_MAJOR << 8) +  UMP_VER_MINOR;
+    umpMess[0] = (uint32_t) ((0xF << 28) + (MIDIENDPOINT_INFO_NOTIFICATION << 16) + (UMP_VER_MAJOR << 8) +  UMP_VER_MINOR);
     umpMess[1] = (numOfFuncBlock << 24)
             + (m2 << 9)
             + (m1 << 8)
@@ -237,7 +237,7 @@ std::array<uint32_t, 4> UMPMessage::mtFMidiEndpointInfoNotify(uint8_t numOfFuncB
 std::array<uint32_t, 4> UMPMessage::mtFMidiEndpointDeviceInfoNotify(std::array<uint8_t, 3> manuId, std::array<uint8_t, 2> familyId,
                                                   std::array<uint8_t, 2> modelId, std::array<uint8_t, 4> version){
     std::array<uint32_t, 4> umpMess = {0,0,0,0};
-    umpMess[0] = (0xF << 28) + (MIDIENDPOINT_DEVICEINFO_NOTIFICATION << 16) /*+  numOfFuncBlock*/;
+    umpMess[0] = (uint32_t) ((0xF << 28) + (MIDIENDPOINT_DEVICEINFO_NOTIFICATION << 16)) /*+  numOfFuncBlock*/;
 
     umpMess[1] = (manuId[0] << 16)
                   + (manuId[1] << 8)
@@ -326,14 +326,14 @@ std::array<uint32_t, 4> UMPMessage::mtFFunctionBlockNameNotify(uint8_t fbIdx, ui
 
 std::array<uint32_t, 4> UMPMessage::mtFStartOfSeq(){
     std::array<uint32_t, 4> umpMess = {0,0,0,0};
-    umpMess[0] = (0xF << 28) + (STARTOFSEQ << 16);
+    umpMess[0] = (uint32_t) ((0xF << 28) + (STARTOFSEQ << 16));
     return umpMess;
 
 }
 
 std::array<uint32_t, 4> UMPMessage::mtFEndOfFile(){
     std::array<uint32_t, 4> umpMess = {0,0,0,0};
-    umpMess[0] = (0xF << 28) + (ENDOFFILE << 16);
+    umpMess[0] = (uint32_t) ((0xF << 28) + (ENDOFFILE << 16));
     return umpMess;
 }
 

--- a/src/umpProcessor.cpp
+++ b/src/umpProcessor.cpp
@@ -257,7 +257,7 @@ void umpProcessor::processUMP(uint32_t UMP){
                 case MIDIENDPOINT_PRODID_NOTIFICATION: {
                         umpData mess = umpData();
                         mess.messageType = mt;
-                        mess.status = status;
+                        mess.status = (uint8_t) status;
                         mess.form = umpMess[0] >> 24 & 0x3;
                         mess.dataLength  = 0;
                     uint8_t text[14];
@@ -265,7 +265,7 @@ void umpProcessor::processUMP(uint32_t UMP){
                         if ((umpMess[0] >> 8) & 0xFF) text[mess.dataLength++] = (umpMess[0] >> 8) & 0xFF;
                         if (umpMess[0] & 0xFF) text[mess.dataLength++] = umpMess[0]  & 0xFF;
                     for(uint8_t i = 1; i<=3; i++){
-                        for(uint8_t j = 24; j>=0; j-=8){
+                        for(int j = 24; j>=0; j-=8){
                             uint8_t c = (umpMess[i] >> j) & 0xFF;
                             if(c){
                                     text[mess.dataLength++]=c;
@@ -280,14 +280,14 @@ void umpProcessor::processUMP(uint32_t UMP){
 
                 case MIDIENDPOINT_PROTOCOL_REQUEST: //JR Protocol Req
                     if(midiEndpointJRProtocolReq != nullptr)
-                        midiEndpointJRProtocolReq((umpMess[0] >> 8),
+                        midiEndpointJRProtocolReq((uint8_t) (umpMess[0] >> 8),
                                                    (umpMess[0] >> 1) & 1,
                                                    umpMess[0] & 1
                                                    );
                     break;
                 case MIDIENDPOINT_PROTOCOL_NOTIFICATION: //JR Protocol Req
                     if(midiEndpointJRProtocolNotify != nullptr)
-                        midiEndpointJRProtocolNotify((umpMess[0] >> 8),
+                        midiEndpointJRProtocolNotify((uint8_t) (umpMess[0] >> 8),
                                                      (umpMess[0] >> 1) & 1,
                                                      umpMess[0] & 1
                                                     );
@@ -321,14 +321,14 @@ void umpProcessor::processUMP(uint32_t UMP){
                     uint8_t fbIdx = (umpMess[0] >> 8) & 0x7F;
                     umpData mess = umpData();
                     mess.messageType = mt;
-                    mess.status = status;
+                    mess.status = (uint8_t) status;
                     mess.form = umpMess[0] >> 24 & 0x3;
                     mess.dataLength  = 0;
                     uint8_t text[13];
 
                     if (umpMess[0] & 0xFF) text[mess.dataLength++] = umpMess[0]  & 0xFF;
                     for(uint8_t i = 1; i<=3; i++){
-                        for(uint8_t j = 24; j>=0; j-=8){
+                        for(int j = 24; j>=0; j-=8){
                             uint8_t c = (umpMess[i] >> j) & 0xFF;
                             if(c){
                                 text[mess.dataLength++]=c;
@@ -487,7 +487,7 @@ void umpProcessor::processUMP(uint32_t UMP){
                         uint8_t text[12];
 
                         for(uint8_t i = 1; i<=3; i++){
-                            for(uint8_t j = 24; j>=0; j-=8){
+                            for(int j = 24; j>=0; j-=8){
                                 uint8_t c = (umpMess[i] >> j) & 0xFF;
                                 if(c){
                                     text[mess.dataLength++]=c;


### PR DESCRIPTION
Make conversions between types explicit because they are flagged as warning in W4 due to potential loss of data.

for(uint8_t j = 24; j>=0; j-=8), j will never be < 0, so this is an infinite loop, switched j to signed, flagged through static analysis tools.

Tested locally while integrating into https://github.com/microsoft/MIDI

