### PR TITLE
Change include parent directory and add CMake export config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,13 @@ add_library(libmidi2
         src/mcoded7.cpp
         )
 
-target_include_directories(libmidi2 PUBLIC ${HEADER_DESTINATION})
+target_include_directories(libmidi2 PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
 
 target_compile_options(libmidi2 PRIVATE -Wall)
 
 install(TARGETS libmidi2 DESTINATION lib)
 file(GLOB HEADERS include/*.h)
-install(FILES ${HEADERS} DESTINATION include)
+install(FILES ${HEADERS} DESTINATION "include/${PROJECT_NAME}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,14 @@ target_include_directories(libmidi2 PUBLIC
 
 target_compile_options(libmidi2 PRIVATE -Wall)
 
-install(TARGETS libmidi2 DESTINATION lib)
+set(LIBMIDI2_EXPORT_NAME libmidi2-config)
+install(TARGETS libmidi2
+        EXPORT ${LIBMIDI2_EXPORT_NAME}
+)
+install(EXPORT ${LIBMIDI2_EXPORT_NAME}
+        NAMESPACE libmidi2::
+        DESTINATION "share/${PROJECT_NAME}"
+)
+
 file(GLOB HEADERS include/*.h)
 install(FILES ${HEADERS} DESTINATION "include/${PROJECT_NAME}")

--- a/src/bytestreamToUMP.cpp
+++ b/src/bytestreamToUMP.cpp
@@ -19,8 +19,8 @@
  * ********************************************************/
 
 
-#include "../include/utils.h"
-#include "../include/bytestreamToUMP.h"
+#include "utils.h"
+#include "bytestreamToUMP.h"
 
 #ifndef clear
 #define clear(dest, c,n ) for(uint16_t i = 0 ; i < n ; i ++) dest[i] = c;

--- a/src/mcoded7.cpp
+++ b/src/mcoded7.cpp
@@ -18,7 +18,7 @@
  *
  * ********************************************************/
 
-#include "../include/mcoded7.h"
+#include "mcoded7.h"
 
 #ifndef clear
 #define clear(dest, c,n ) for(uint16_t i = 0 ; i < n ; i ++) dest[i] = c;

--- a/src/midiCIMessageCreate.cpp
+++ b/src/midiCIMessageCreate.cpp
@@ -18,7 +18,7 @@
  *
  * ********************************************************/
 
-#include "../include/midiCIMessageCreate.h"
+#include "midiCIMessageCreate.h"
 
 void setBytesFromNumbers(uint8_t *message, uint32_t number, uint16_t *start, uint8_t amount) {
     for (int amountC = amount; amountC > 0; amountC--) {

--- a/src/midiCIProcessor.cpp
+++ b/src/midiCIProcessor.cpp
@@ -18,7 +18,7 @@
  * 
  * ********************************************************/
 
-#include "../include/midiCIProcessor.h"
+#include "midiCIProcessor.h"
 
 void midiCIProcessor::endSysex7(){
     if(midici._reqTupleSet){

--- a/src/umpMessageCreate.cpp
+++ b/src/umpMessageCreate.cpp
@@ -17,8 +17,8 @@
  * SOFTWARE.
  * 
  * ********************************************************/
-#include "../include/utils.h"
-#include "../include/umpMessageCreate.h"
+#include "utils.h"
+#include "umpMessageCreate.h"
 
 
 

--- a/src/umpProcessor.cpp
+++ b/src/umpProcessor.cpp
@@ -18,7 +18,7 @@
  * 
  * ********************************************************/
 
-#include "../include/umpProcessor.h"
+#include "umpProcessor.h"
 
 void umpProcessor::clearUMP(){
     messPos = 0;

--- a/src/umpToBytestream.cpp
+++ b/src/umpToBytestream.cpp
@@ -19,8 +19,8 @@
  * ********************************************************/
 
 
-#include "../include/utils.h"
-#include "../include/umpToBytestream.h"
+#include "utils.h"
+#include "umpToBytestream.h"
 
 umpToBytestream::umpToBytestream(){}
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -18,7 +18,7 @@
  * 
  * ********************************************************/
 
-#include "../include/utils.h"
+#include "utils.h"
 
 // power of 2, pow(exp)
 uint32_t power_of_2(uint8_t exp)


### PR DESCRIPTION
### Changes
* Remove include relative parent directory
* Add the `include` by `target_include_directories` of target `libmidi2`
* Change headers install path from `include` to `include/libmidi2`
* Add CMake target export config with namespace `libmidi2::`

### Test
Simple test passed with `#include "libmidi2/utils.h"` by `find_package`
```cmake
find_package(libmidi2 CONFIG REQUIRED)
target_link_libraries(main PRIVATE libmidi2::libmidi2)
```