### PR TITLE
Add the test harness to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,26 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(libmidi2)
-set(CMAKE_CXX_STANDARD 17)
 
-add_library(libmidi2
+function(setupTarget target)
+    target_compile_options("${target}" PRIVATE -Wall)
+    target_compile_features("${target}" PUBLIC cxx_std_11)
+endfunction()
+
+set(INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
+set(LIBMIDI2_HEADERS
+    "${INCLUDE_DIR}/bytestreamToUMP.h"
+    "${INCLUDE_DIR}/mcoded7.h"
+    "${INCLUDE_DIR}/midiCIMessageCreate.h"
+    "${INCLUDE_DIR}/midiCIProcessor.h"
+    "${INCLUDE_DIR}/umpMessageCreate.h"
+    "${INCLUDE_DIR}/umpProcessor.h"
+    "${INCLUDE_DIR}/umpToBytestream.h"
+    "${INCLUDE_DIR}/umpToMIDI1Protocol.h"
+    "${INCLUDE_DIR}/utils.h"
+)
+
+add_library(libmidi2 ${LIBMIDI2_HEADERS}
         src/utils.cpp
         src/bytestreamToUMP.cpp
         src/umpToBytestream.cpp
@@ -14,13 +31,12 @@ add_library(libmidi2
         src/umpProcessor.cpp
         src/mcoded7.cpp
         )
+setupTarget(libmidi2)
 
 target_include_directories(libmidi2 PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${INCLUDE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
-
-target_compile_options(libmidi2 PRIVATE -Wall)
 
 set(LIBMIDI2_EXPORT_NAME libmidi2-config)
 install(TARGETS libmidi2
@@ -31,5 +47,8 @@ install(EXPORT ${LIBMIDI2_EXPORT_NAME}
         DESTINATION "share/${PROJECT_NAME}"
 )
 
-file(GLOB HEADERS include/*.h)
-install(FILES ${HEADERS} DESTINATION "include/${PROJECT_NAME}")
+install(FILES ${LIBMIDI2_HEADERS} DESTINATION "include/${PROJECT_NAME}")
+
+add_executable(tests tests.cpp)
+target_link_libraries(tests PRIVATE libmidi2)
+setupTarget(tests)


### PR DESCRIPTION
Beyond adding the tests executable, there are a few further tweaks...

- Add the header files to the libmidi2 target so that they show up in an IDE. These aren't strictly necessary but it's very useful to see the header files alongside the sources. This also allows the includes to be explicitly installed rather than relying on globbing.
- Compile for C++11 rather than 17 as per the makefile. (I'm assuming that the makefile is "canonical" here. Let me know if that's wrong!)
- Use the "modern" CMake target_compile_features() to select the C++ standard rather than setting CMAKE_CXX_STANDARD. 
- Factor out a couple of uses of the library include directory path as an INCLUDE_DIR variable.
- Create a setupTarget() function for consistency between libmidi2 and tests targets.