### PR TITLE
Eliminate the "clear" macro in favor of an inline function.

### DIFF
--- a/include/bytestreamToUMP.h
+++ b/include/bytestreamToUMP.h
@@ -24,10 +24,6 @@
 
 #define BSTOUMP_BUFFER 4
 
-#ifndef clear
-#define clear(dest, c,n ) for(uint16_t i = 0 ; i < n ; i ++) dest[i] = c;
-#endif
-
 #include "utils.h"
 
 class bytestreamToUMP{
@@ -194,6 +190,7 @@ class bytestreamToUMP{
 		bool outputMIDI2 = false;
 		
 		bytestreamToUMP(){
+			using M2Utils::clear;
 			clear(bankMSB, 255, sizeof(bankMSB));
 			clear(bankLSB, 255, sizeof(bankLSB));
 			clear(rpnMsbValue, 255, sizeof(rpnMsbValue));
@@ -243,7 +240,7 @@ class bytestreamToUMP{
 						increaseWrite();
 
 						sysex7State = 0;
-						clear(sysex, 0, sizeof(sysex));
+						M2Utils::clear(sysex, 0, sizeof(sysex));
 					}
 			} else if(sysex7State >= 1){
 				//Check IF new UMP Message Type 3
@@ -255,7 +252,7 @@ class bytestreamToUMP{
 					increaseWrite();
 					umpMess[writeIndex] = ((sysex[2] + 0L) << 24) + ((sysex[3] + 0L)<< 16) + (sysex[4] << 8) + sysex[5] + 0L;
 					increaseWrite();
-					clear(sysex, 0, sizeof(sysex));
+					M2Utils::clear(sysex, 0, sizeof(sysex));
 					sysex7State=2;
 					sysex7Pos=0;
 				}

--- a/include/utils.h
+++ b/include/utils.h
@@ -168,6 +168,12 @@
 #define UMP_MIDI_ENDPOINT 0xF
 
 namespace M2Utils {
+ inline void clear(uint8_t * const dest, uint8_t const c, std::size_t const n) {
+  for (auto i = std::size_t{0}; i < n; i++) {
+   dest[i] = c;
+  }
+ }
+
  inline uint32_t scaleUp(uint32_t srcVal, uint8_t srcBits, uint8_t dstBits){
   //Handle value of 0 - skip processing
   if(srcVal == 0){

--- a/src/mcoded7.cpp
+++ b/src/mcoded7.cpp
@@ -19,16 +19,12 @@
  * ********************************************************/
 
 #include "mcoded7.h"
-
-#ifndef clear
-#define clear(dest, c,n ) for(uint16_t i = 0 ; i < n ; i ++) dest[i] = c;
-#endif
-
+#include "utils.h"
 
 uint16_t mcoded7Decode::currentPos(){ return dumpPos;}
 
 void mcoded7Decode::reset(){
-    clear(dump,0,7);
+    M2Utils::clear(dump,0,7);
     fBit=0; bits=0;dumpPos=255;
 }
 
@@ -47,7 +43,7 @@ void mcoded7Decode::parseS7Byte(uint8_t s7Byte){
 uint16_t mcoded7Encode::currentPos(){ return dumpPos-1;}
 
 void mcoded7Encode::reset(){
-    clear(dump,0,8);
+    M2Utils::clear(dump,0,8);
     dumpPos=1; cnt = 6;
 }
 


### PR DESCRIPTION
When compiling using libcxx and C++17 (see also PR #9!) the <atomic_flag> include is dragged in by one of the standard library headers. atomic_flag declares a [clear() member function](https://en.cppreference.com/w/cpp/atomic/atomic_flag/clear). The clear macro causes this to expand to something that won't compile.

This change creates a clear() function in utils.h. This seemed like a logical place for it to live!