### PR TITLE
fix: change pitch bend variable type from uint8_t to uint32_t for imp…

### DIFF
--- a/include/umpToMIDI2Protocol.h
+++ b/include/umpToMIDI2Protocol.h
@@ -269,7 +269,7 @@ public:
                         case 0xE0: //Pitch bend
                             out1 = ((0x04 << 4) + group) << 24;
                             out1 += (status + channel) << 16;
-                            uint8_t pb = (val2 << 7) + val1;
+                            uint32_t pb = (val2 << 7) + val1;
                             out2 += M2Utils::scaleUp(pb, 14, 32);
                             umpMess[writeIndex] = out1;
                             increaseWrite();


### PR DESCRIPTION
I found a bug in PitchBend value conversion in MIDI 1.0 to MIDI 2.0 Protocol.
The variable to store 14bit value was set to **uint8_t**, so I changed it to **uint32_t**.