### PR TITLE
Add Flex Data creation, per-note expression, fix parser bugs

### DIFF
--- a/include/umpMessageCreate.h
+++ b/include/umpMessageCreate.h
@@ -291,7 +291,8 @@ inline std::array<uint32_t, 4> mt5MDSPayload(uint8_t group, uint8_t mds, uint8_t
     }
 
 // Flex Data (MT=0xD) creation functions
-// addrs: 0=Channel, 1=Group, 0xFF=NoChannel  form: 0=Complete, 1=Start, 2=Continue, 3=End
+// addrs: 0=Channel, 1=Group (2-bit field, masked to 0x3)
+// form:  0=Complete, 1=Start, 2=Continue, 3=End
 
 inline std::array<uint32_t, 4> mtDFlexData(uint8_t group, uint8_t form, uint8_t addrs,
                                             uint8_t channel, uint8_t statusBank, uint8_t status){

--- a/include/umpMessageCreate.h
+++ b/include/umpMessageCreate.h
@@ -230,6 +230,39 @@ inline std::array<uint32_t, 2> mt4ProgramChange(uint8_t group, uint8_t channel, 
 	return umpMess;
 }
 
+    // Per-Note Expression (MIDI 2.0)
+    inline std::array<uint32_t, 2> mt4PerNotePitchBend(uint8_t group, uint8_t channel,
+                                                        uint8_t noteNumber, uint32_t pitch){
+        std::array<uint32_t, 2> umpMess = {0,0};
+        umpMess[0] = mt4CreateFirstWord(group, PITCH_BEND_PERNOTE, channel, noteNumber, 0);
+        umpMess[1] = pitch;
+        return umpMess;
+    }
+
+    inline std::array<uint32_t, 2> mt4PerNoteCC(uint8_t group, uint8_t channel,
+                                                 uint8_t noteNumber, uint8_t index, uint32_t value){
+        std::array<uint32_t, 2> umpMess = {0,0};
+        umpMess[0] = mt4CreateFirstWord(group, NRPN_PERNOTE, channel, noteNumber, index);
+        umpMess[1] = value;
+        return umpMess;
+    }
+
+    inline std::array<uint32_t, 2> mt4PerNoteRPN(uint8_t group, uint8_t channel,
+                                                  uint8_t noteNumber, uint8_t index, uint32_t value){
+        std::array<uint32_t, 2> umpMess = {0,0};
+        umpMess[0] = mt4CreateFirstWord(group, RPN_PERNOTE, channel, noteNumber, index);
+        umpMess[1] = value;
+        return umpMess;
+    }
+
+    inline std::array<uint32_t, 2> mt4PerNoteManage(uint8_t group, uint8_t channel,
+                                                     uint8_t noteNumber, uint8_t optionFlags){
+        std::array<uint32_t, 2> umpMess = {0,0};
+        umpMess[0] = mt4CreateFirstWord(group, PERNOTE_MANAGE, channel, noteNumber, optionFlags);
+        umpMess[1] = 0;
+        return umpMess;
+    }
+
     //TODO mt5 Sysex8
 inline std::array<uint32_t, 4> mt5MDSHeader(uint8_t group, uint8_t mds, uint16_t numberOfBytes, uint16_t totalChunks, uint16_t chunkNumber,
                                             uint16_t manuId, uint16_t deviceId, uint16_t subId1, uint16_t subId2){
@@ -257,7 +290,118 @@ inline std::array<uint32_t, 4> mt5MDSPayload(uint8_t group, uint8_t mds, uint8_t
         return umpMess;
     }
 
-//TODO mtD*
+// Flex Data (MT=0xD) creation functions
+// addrs: 0=Channel, 1=Group, 0xFF=NoChannel  form: 0=Complete, 1=Start, 2=Continue, 3=End
+
+inline std::array<uint32_t, 4> mtDFlexData(uint8_t group, uint8_t form, uint8_t addrs,
+                                            uint8_t channel, uint8_t statusBank, uint8_t status){
+    std::array<uint32_t, 4> umpMess = {0,0,0,0};
+    umpMess[0] = ((uint32_t)UMP_FLEX_DATA << 28)
+               + (((uint32_t)group & 0xF) << 24)
+               + (((uint32_t)form  & 0x3) << 22)
+               + (((uint32_t)addrs & 0x3) << 20)
+               + (((uint32_t)channel & 0xF) << 16)
+               + (((uint32_t)statusBank & 0xFF) << 8)
+               + ((uint32_t)status & 0xFF);
+    return umpMess;
+}
+
+inline std::array<uint32_t, 4> mtDFlexTempo(uint8_t group, uint8_t addrs, uint8_t channel,
+                                             uint32_t num10nsPQN){
+    auto umpMess = mtDFlexData(group, 0, addrs, channel, FLEXDATA_COMMON, FLEXDATA_COMMON_TEMPO);
+    umpMess[1] = num10nsPQN;
+    return umpMess;
+}
+
+inline std::array<uint32_t, 4> mtDFlexTimeSig(uint8_t group, uint8_t addrs, uint8_t channel,
+                                               uint8_t numerator, uint8_t denominator,
+                                               uint8_t num32Notes){
+    auto umpMess = mtDFlexData(group, 0, addrs, channel, FLEXDATA_COMMON, FLEXDATA_COMMON_TIMESIG);
+    umpMess[1] = ((uint32_t)numerator  << 24)
+               + ((uint32_t)denominator << 16)
+               + ((uint32_t)num32Notes  <<  8);
+    return umpMess;
+}
+
+inline std::array<uint32_t, 4> mtDFlexMetronome(uint8_t group, uint8_t addrs, uint8_t channel,
+                                                 uint8_t numClkpPriCli, uint8_t bAccP1,
+                                                 uint8_t bAccP2, uint8_t bAccP3,
+                                                 uint8_t numSubDivCli1, uint8_t numSubDivCli2){
+    auto umpMess = mtDFlexData(group, 0, addrs, channel, FLEXDATA_COMMON, FLEXDATA_COMMON_METRONOME);
+    umpMess[1] = ((uint32_t)numClkpPriCli << 24)
+               + ((uint32_t)bAccP1        << 16)
+               + ((uint32_t)bAccP2        <<  8)
+               + ((uint32_t)bAccP3);
+    umpMess[2] = ((uint32_t)numSubDivCli1 << 24)
+               + ((uint32_t)numSubDivCli2 << 16);
+    return umpMess;
+}
+
+inline std::array<uint32_t, 4> mtDFlexKeySig(uint8_t group, uint8_t addrs, uint8_t channel,
+                                              uint8_t sharpFlats, uint8_t tonic){
+    auto umpMess = mtDFlexData(group, 0, addrs, channel, FLEXDATA_COMMON, FLEXDATA_COMMON_KEYSIG);
+    umpMess[1] = ((uint32_t)sharpFlats << 24)
+               + ((uint32_t)tonic      << 16);
+    return umpMess;
+}
+
+inline std::array<uint32_t, 4> mtDFlexChord(uint8_t group, uint8_t addrs, uint8_t channel,
+                                             uint8_t chShrpFlt, uint8_t chTonic,
+                                             uint8_t chType,
+                                             uint8_t chAlt1Type, uint8_t chAlt1Deg,
+                                             uint8_t chAlt2Type, uint8_t chAlt2Deg,
+                                             uint8_t chAlt3Type, uint8_t chAlt3Deg,
+                                             uint8_t chAlt4Type, uint8_t chAlt4Deg,
+                                             uint8_t baShrpFlt,  uint8_t baTonic,
+                                             uint8_t baType,
+                                             uint8_t baAlt1Type, uint8_t baAlt1Deg,
+                                             uint8_t baAlt2Type, uint8_t baAlt2Deg){
+    auto umpMess = mtDFlexData(group, 0, addrs, channel, FLEXDATA_COMMON, FLEXDATA_COMMON_CHORD);
+    umpMess[1] = (((uint32_t)chShrpFlt  & 0xF) << 28)
+               + (((uint32_t)chTonic    & 0xF) << 24)
+               + (((uint32_t)chType     & 0xFF) << 16)
+               + (((uint32_t)chAlt1Type & 0xF) << 12)
+               + (((uint32_t)chAlt1Deg  & 0xF) <<  8)
+               + (((uint32_t)chAlt2Type & 0xF) <<  4)
+               + ( (uint32_t)chAlt2Deg  & 0xF);
+    umpMess[2] = (((uint32_t)chAlt3Type & 0xF) << 28)
+               + (((uint32_t)chAlt3Deg  & 0xF) << 24)
+               + (((uint32_t)chAlt4Type & 0xF) << 20)
+               + (((uint32_t)chAlt4Deg  & 0xF) << 16);
+    umpMess[3] = (((uint32_t)baShrpFlt  & 0xF) << 28)
+               + (((uint32_t)baTonic    & 0xF) << 24)
+               + (((uint32_t)baType     & 0xFF) << 16)
+               + (((uint32_t)baAlt1Type & 0xF) << 12)
+               + (((uint32_t)baAlt1Deg  & 0xF) <<  8)
+               + (((uint32_t)baAlt2Type & 0xF) <<  4)
+               + ( (uint32_t)baAlt2Deg  & 0xF);
+    return umpMess;
+}
+
+inline std::array<uint32_t, 4> mtDFlexTextData(uint8_t group, uint8_t form, uint8_t addrs,
+                                                uint8_t channel, uint8_t statusBank,
+                                                uint8_t status, uint8_t* text, uint8_t textLen){
+    auto umpMess = mtDFlexData(group, form, addrs, channel, statusBank, status);
+    uint8_t offset = 0;
+    for(uint8_t i = 1; i <= 3; i++){
+        for(int shift = 24; shift >= 0; shift -= 8){
+            if(offset < textLen) umpMess[i] += ((uint32_t)text[offset++] << shift);
+        }
+    }
+    return umpMess;
+}
+
+inline std::array<uint32_t, 4> mtDFlexPerformance(uint8_t group, uint8_t form, uint8_t addrs,
+                                                   uint8_t channel, uint8_t status,
+                                                   uint8_t* text, uint8_t textLen){
+    return mtDFlexTextData(group, form, addrs, channel, FLEXDATA_PERFORMANCE, status, text, textLen);
+}
+
+inline std::array<uint32_t, 4> mtDFlexLyric(uint8_t group, uint8_t form, uint8_t addrs,
+                                             uint8_t channel, uint8_t status,
+                                             uint8_t* text, uint8_t textLen){
+    return mtDFlexTextData(group, form, addrs, channel, FLEXDATA_LYRIC, status, text, textLen);
+}
 
 inline std::array<uint32_t, 4> mtFMidiEndpoint(uint8_t filter){
     std::array<uint32_t, 4> umpMess  = {0,0,0,0};

--- a/src/umpProcessor.cpp
+++ b/src/umpProcessor.cpp
@@ -443,8 +443,8 @@ void umpProcessor::processUMP(uint32_t UMP){
             mess.messageType = mt;
             mess.status = umpMess[0] & 0xFF;
             mess.statusBank = (umpMess[0] >> 8) & 0xFF;
-            mess.form = (umpMess[0] >> 20) & 3;
-            mess.addrs = (umpMess[0] >> 18) & 3;
+            mess.form = (umpMess[0] >> 22) & 3;
+            mess.addrs = (umpMess[0] >> 20) & 3;
             mess.data = umpMess;
 
             //SysEx 8
@@ -504,7 +504,7 @@ void umpProcessor::processUMP(uint32_t UMP){
                                                                (umpMess[3] >> 12) & 0xF,//baAlt1Type
                                                                (umpMess[3] >> 8) & 0xF,//baAlt1Deg
                                                                (umpMess[3] >> 4) & 0xF,//baAlt2Type
-                                                               umpMess[1] & 0xF//baAlt2Deg
+                                                               umpMess[3] & 0xF//baAlt2Deg
                                 );
                             else if (flexData != nullptr) flexData(mess);
                             break;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -442,6 +442,49 @@ int main(){
     passFail(rtPNValue, 0xABCD1234);
     printf(" PerNoteCC roundtrip\n");
 
+    // mt4PerNoteRPN: group=1, ch=2, note=64, index=5 (RPN bank 0), value=0x12345678
+    // word0: MT=4 group=1 status=0x00(RPN_PERNOTE) ch=2 note=64 index=5
+    //        0x41024005
+    auto pnrpn = UMPMessage::mt4PerNoteRPN(1, 2, 64, 5, 0x12345678);
+    uint32_t inPNRPN[] = {pnrpn[0], pnrpn[1]};
+    uint32_t outPNRPN[] = {0x41024005, 0x12345678};
+    testRun_umpToump(" mt4PerNoteRPN note=64 idx=5 : ", inPNRPN, 2, outPNRPN);
+
+    // mt4PerNoteManage: group=0, ch=0, note=60, optionFlags=3 (detach+reset)
+    // word0: MT=4 group=0 status=0xF0(PERNOTE_MANAGE) ch=0 note=60 flags=3
+    //        0x40F03c03
+    auto pnman = UMPMessage::mt4PerNoteManage(0, 0, 60, 3);
+    uint32_t inPNMan[] = {pnman[0], pnman[1]};
+    uint32_t outPNMan[] = {0x40f03c03, 0x00000000};
+    testRun_umpToump(" mt4PerNoteManage note=60 flags=3 : ", inPNMan, 2, outPNMan);
+
+    //***** Flex Metronome Roundtrip *************
+    printf("Flex Metronome Roundtrip \n");
+
+    uint8_t rtMetClk = 0, rtMetAcc1 = 0, rtMetAcc2 = 0, rtMetAcc3 = 0;
+    uint8_t rtMetSub1 = 0, rtMetSub2 = 0;
+    proc.setFlexMetronome([&](struct umpFlexData mess, uint8_t numClkpPriCli,
+                              uint8_t bAccP1, uint8_t bAccP2, uint8_t bAccP3,
+                              uint8_t numSubDivCli1, uint8_t numSubDivCli2){
+        (void) mess;
+        rtMetClk  = numClkpPriCli;
+        rtMetAcc1 = bAccP1;
+        rtMetAcc2 = bAccP2;
+        rtMetAcc3 = bAccP3;
+        rtMetSub1 = numSubDivCli1;
+        rtMetSub2 = numSubDivCli2;
+    });
+
+    auto rtMet = UMPMessage::mtDFlexMetronome(0, 0, 0, 24, 2, 1, 0, 4, 3);
+    for(int i=0; i<4; i++) proc.processUMP(rtMet[i]);
+    passFail(rtMetClk,  24);
+    passFail(rtMetAcc1, 2);
+    passFail(rtMetAcc2, 1);
+    passFail(rtMetAcc3, 0);
+    passFail(rtMetSub1, 4);
+    passFail(rtMetSub2, 3);
+    printf(" FlexMetronome roundtrip\n");
+
     ///****************************
     printf("Tests Passed: %d    Failed : %d\n",testPassed, testFailed);
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -6,6 +6,7 @@
 #include "../include/umpToBytestream.h"
 #include "../include/umpToMIDI1Protocol.h"
 #include "../include/umpMessageCreate.h"
+#include "../include/umpProcessor.h"
 #include <cstdio>
 
 #include "umpToMIDI2Protocol.h"
@@ -264,6 +265,182 @@ int main(){
     uint32_t inUmp2[] = {UMPMessage::mt1TimingClock(8)};
     uint32_t outUmp2[] = {0x18f80000};
     testRun_umpToump(" UMP Timing Clock : ", inUmp2,  1, outUmp2);
+
+    //***** Flex Data (MT=0xD) *************
+    printf("Flex Data MT=0xD Create \n");
+
+    auto tempo = UMPMessage::mtDFlexTempo(0, 0, 0, 500000000);
+    uint32_t inTempo[] = {tempo[0], tempo[1], tempo[2], tempo[3]};
+    uint32_t outTempo[] = {0xd0000000, 0x1dcd6500, 0x00000000, 0x00000000};
+    testRun_umpToump(" mtDFlexTempo 120bpm : ", inTempo, 4, outTempo);
+
+    auto keysig = UMPMessage::mtDFlexKeySig(0, 0, 0, 2, 0);
+    uint32_t inKeySig[] = {keysig[0], keysig[1], keysig[2], keysig[3]};
+    uint32_t outKeySig[] = {0xd0000005, 0x02000000, 0x00000000, 0x00000000};
+    testRun_umpToump(" mtDFlexKeySig D major (2 sharps) : ", inKeySig, 4, outKeySig);
+
+    auto timesig = UMPMessage::mtDFlexTimeSig(0, 0, 0, 4, 2, 8);
+    uint32_t inTimeSig[] = {timesig[0], timesig[1], timesig[2], timesig[3]};
+    uint32_t outTimeSig[] = {0xd0000001, 0x04020800, 0x00000000, 0x00000000};
+    testRun_umpToump(" mtDFlexTimeSig 4/4 : ", inTimeSig, 4, outTimeSig);
+
+    auto chord = UMPMessage::mtDFlexChord(0, 0, 0, 0,0,1, 0,0,0,0, 0,0,0,0, 0,0,0, 0,0,0,0);
+    uint32_t inChord[] = {chord[0], chord[1], chord[2], chord[3]};
+    uint32_t outChord[] = {0xd0000006, 0x00010000, 0x00000000, 0x00000000};
+    testRun_umpToump(" mtDFlexChord C major no bass : ", inChord, 4, outChord);
+
+    // Flex Data with addrs=1 (Group) — verifies bits 21-20
+    auto keysigGrp = UMPMessage::mtDFlexKeySig(0, 1, 0, 2, 0);
+    uint32_t inKeySigGrp[] = {keysigGrp[0], keysigGrp[1], keysigGrp[2], keysigGrp[3]};
+    uint32_t outKeySigGrp[] = {0xd0100005, 0x02000000, 0x00000000, 0x00000000};
+    testRun_umpToump(" mtDFlexKeySig addrs=Group : ", inKeySigGrp, 4, outKeySigGrp);
+
+    // Flex Data with form=1 (Start) — verifies bits 23-22
+    uint8_t perfText[] = {'H', 'i'};
+    auto perf = UMPMessage::mtDFlexPerformance(1, 1, 0, 5, 0, perfText, 2);
+    uint32_t inPerf[] = {perf[0], perf[1], perf[2], perf[3]};
+    uint32_t outPerf[] = {0xd1450100, 0x48690000, 0x00000000, 0x00000000};
+    testRun_umpToump(" mtDFlexPerformance form=Start ch=5 : ", inPerf, 4, outPerf);
+
+    // Flex Data with form=3 (End), addrs=1, ch=9 — exercises all bit fields
+    uint8_t lyricText[] = {'!', '!'};
+    auto lyric = UMPMessage::mtDFlexLyric(2, 3, 1, 9, 0, lyricText, 2);
+    uint32_t inLyric[] = {lyric[0], lyric[1], lyric[2], lyric[3]};
+    uint32_t outLyric[] = {0xd2d90200, 0x21210000, 0x00000000, 0x00000000};
+    testRun_umpToump(" mtDFlexLyric form=End addrs=Group ch=9 : ", inLyric, 4, outLyric);
+
+    //***** Flex Data Roundtrip (create -> processUMP -> callback) *************
+    printf("Flex Data Roundtrip \n");
+
+    umpProcessor proc;
+
+    // Roundtrip: FlexTempo
+    uint32_t rtTempoVal = 0;
+    proc.setFlexTempo([&](struct umpFlexData mess, uint32_t num10nsPQN){
+        rtTempoVal = num10nsPQN;
+    });
+    auto rtTempo = UMPMessage::mtDFlexTempo(0, 0, 0, 500000000);
+    for(int i=0; i<4; i++) proc.processUMP(rtTempo[i]);
+    passFail(rtTempoVal, 500000000);
+    printf(" FlexTempo roundtrip\n");
+
+    // Roundtrip: FlexKeySig
+    uint8_t rtSharpFlats = 0, rtTonic = 0;
+    proc.setFlexKeySig([&](struct umpFlexData mess, uint8_t sf, uint8_t t){
+        rtSharpFlats = sf;
+        rtTonic = t;
+    });
+    auto rtKeySig = UMPMessage::mtDFlexKeySig(0, 0, 0, 3, 5);
+    for(int i=0; i<4; i++) proc.processUMP(rtKeySig[i]);
+    passFail(rtSharpFlats, 3);
+    passFail(rtTonic, 5);
+    printf(" FlexKeySig roundtrip\n");
+
+    // Roundtrip: FlexTimeSig
+    uint8_t rtNum = 0, rtDenom = 0, rtN32 = 0;
+    proc.setFlexTimeSig([&](struct umpFlexData mess, uint8_t n, uint8_t d, uint8_t n32){
+        rtNum = n; rtDenom = d; rtN32 = n32;
+    });
+    auto rtTimeSig = UMPMessage::mtDFlexTimeSig(0, 0, 0, 6, 3, 16);
+    for(int i=0; i<4; i++) proc.processUMP(rtTimeSig[i]);
+    passFail(rtNum, 6);
+    passFail(rtDenom, 3);
+    passFail(rtN32, 16);
+    printf(" FlexTimeSig roundtrip\n");
+
+    // Roundtrip: FlexChord — exercises all 18 chord parameters + verifies baAlt2Deg fix
+    uint8_t rtChShrpFlt=0, rtChTonic=0, rtChType=0;
+    uint8_t rtChAlt1T=0, rtChAlt1D=0, rtChAlt2T=0, rtChAlt2D=0;
+    uint8_t rtChAlt3T=0, rtChAlt3D=0, rtChAlt4T=0, rtChAlt4D=0;
+    uint8_t rtBaShrpFlt=0, rtBaTonic=0, rtBaType=0;
+    uint8_t rtBaAlt1T=0, rtBaAlt1D=0, rtBaAlt2T=0, rtBaAlt2D=0;
+    proc.setFlexChord([&](struct umpFlexData mess,
+        uint8_t a, uint8_t b, uint8_t c,
+        uint8_t d, uint8_t e, uint8_t f, uint8_t g,
+        uint8_t h, uint8_t i, uint8_t j, uint8_t k,
+        uint8_t l, uint8_t m, uint8_t n,
+        uint8_t o, uint8_t p, uint8_t q, uint8_t r){
+        rtChShrpFlt=a; rtChTonic=b; rtChType=c;
+        rtChAlt1T=d; rtChAlt1D=e; rtChAlt2T=f; rtChAlt2D=g;
+        rtChAlt3T=h; rtChAlt3D=i; rtChAlt4T=j; rtChAlt4D=k;
+        rtBaShrpFlt=l; rtBaTonic=m; rtBaType=n;
+        rtBaAlt1T=o; rtBaAlt1D=p; rtBaAlt2T=q; rtBaAlt2D=r;
+    });
+    // Use distinct non-zero values for every parameter to catch any mix-up
+    auto rtChord = UMPMessage::mtDFlexChord(0, 0, 0,
+        2, 3, 0x15,       // chShrpFlt=2, chTonic=3(Eb), chType=0x15
+        1, 2, 3, 4,       // alt1-2
+        5, 6, 7, 8,       // alt3-4
+        9, 10, 0x20,      // baShrpFlt=9, baTonic=10, baType=0x20
+        11, 12, 13, 14);  // baAlt1-2
+    for(int i=0; i<4; i++) proc.processUMP(rtChord[i]);
+    passFail(rtChShrpFlt, 2); passFail(rtChTonic, 3); passFail(rtChType, 0x15);
+    passFail(rtChAlt1T, 1); passFail(rtChAlt1D, 2);
+    passFail(rtChAlt2T, 3); passFail(rtChAlt2D, 4);
+    passFail(rtChAlt3T, 5); passFail(rtChAlt3D, 6);
+    passFail(rtChAlt4T, 7); passFail(rtChAlt4D, 8);
+    passFail(rtBaShrpFlt, 9); passFail(rtBaTonic, 10); passFail(rtBaType, 0x20);
+    passFail(rtBaAlt1T, 11); passFail(rtBaAlt1D, 12);
+    passFail(rtBaAlt2T, 13); passFail(rtBaAlt2D, 14);
+    printf(" FlexChord roundtrip (18 params)\n");
+
+    // Roundtrip: FlexPerformance with form verification
+    uint8_t rtPerfForm = 0xFF;
+    uint8_t rtPerfData[12] = {};
+    uint8_t rtPerfLen = 0;
+    proc.setFlexPerformance([&](struct umpFlexData mess, uint8_t* data, uint8_t len){
+        rtPerfForm = mess.form;
+        rtPerfLen = len;
+        for(int i=0; i<len && i<12; i++) rtPerfData[i] = data[i];
+    });
+    uint8_t rtPerfText[] = {'T','e','s','t'};
+    auto rtPerf = UMPMessage::mtDFlexPerformance(0, 0, 0, 0, 0, rtPerfText, 4);
+    for(int i=0; i<4; i++) proc.processUMP(rtPerf[i]);
+    passFail(rtPerfForm, 0);
+    passFail(rtPerfLen, 4);
+    passFail(rtPerfData[0], 'T');
+    passFail(rtPerfData[1], 'e');
+    passFail(rtPerfData[2], 's');
+    passFail(rtPerfData[3], 't');
+    printf(" FlexPerformance roundtrip\n");
+
+    //***** Per-Note Expression *************
+    printf("Per-Note Expression Create \n");
+
+    auto pnpb = UMPMessage::mt4PerNotePitchBend(0, 0, 60, 0x80000000);
+    uint32_t inPNPB[] = {pnpb[0], pnpb[1]};
+    uint32_t outPNPB[] = {0x40603c00, 0x80000000};
+    testRun_umpToump(" mt4PerNotePitchBend note=60 center : ", inPNPB, 2, outPNPB);
+
+    auto pncc = UMPMessage::mt4PerNoteCC(0, 0, 60, 74, 0xFFFFFFFF);
+    uint32_t inPNCC[] = {pncc[0], pncc[1]};
+    uint32_t outPNCC[] = {0x40103c4a, 0xffffffff};
+    testRun_umpToump(" mt4PerNoteCC note=60 CC74 max : ", inPNCC, 2, outPNCC);
+
+    //***** Per-Note Roundtrip *************
+    printf("Per-Note Roundtrip \n");
+
+    uint8_t rtPNNote = 0;
+    uint32_t rtPNValue = 0;
+    uint8_t rtPNStatus = 0;
+    proc.setCVM([&](struct umpCVM mess){
+        rtPNNote = mess.note;
+        rtPNValue = mess.value;
+        rtPNStatus = mess.status;
+    });
+
+    auto rtPNPB = UMPMessage::mt4PerNotePitchBend(0, 0, 60, 0x80000000);
+    for(int i=0; i<2; i++) proc.processUMP(rtPNPB[i]);
+    passFail(rtPNNote, 60);
+    passFail(rtPNValue, 0x80000000);
+    passFail(rtPNStatus, PITCH_BEND_PERNOTE);
+    printf(" PerNotePitchBend roundtrip\n");
+
+    auto rtPNCC = UMPMessage::mt4PerNoteCC(0, 3, 48, 74, 0xABCD1234);
+    for(int i=0; i<2; i++) proc.processUMP(rtPNCC[i]);
+    passFail(rtPNNote, 48);
+    passFail(rtPNValue, 0xABCD1234);
+    printf(" PerNoteCC roundtrip\n");
 
     ///****************************
     printf("Tests Passed: %d    Failed : %d\n",testPassed, testFailed);


### PR DESCRIPTION
Hey Andrew,

I've been working on MIDI 2.0 integration for ESP32-S3 and needed the Flex Data creation functions that were marked as TODO. So I went ahead and implemented them, along with a few per-note expression helpers (pitch bend, CC, RPN, management).

While testing I also ran into a couple of parser bugs in umpProcessor.cpp — the form/addrs bit positions in the Flex Data parser were shifted (overlapping with channel bits), and the flexChord callback was reading baAlt2Deg from the wrong UMP word. Both fixed and covered with roundtrip tests.

All 222 tests passing. Let me know if you'd like any changes.