### PR TITLE
Fix UMP translations

### DIFF
--- a/include/umpToBytestream.h
+++ b/include/umpToBytestream.h
@@ -144,6 +144,8 @@ class umpToBytestream{
                                 bsOut[writeIndex] = UMP & 0x7F;
                                 increaseWrite();
                             }
+                            // System Common (F1-F6) cancels running status; Real Time (F8+) does not.
+                            if (sysByte < 0xF8) { lastRunningStatus = 255; }
                             return;
                             break;
                         }
@@ -224,6 +226,8 @@ class umpToBytestream{
                                 bsOut[writeIndex] = SYSEX_STOP;
                                 increaseWrite();
                             }
+                            // System Exclusive cancels running status.
+                            lastRunningStatus = 255;
                             break;
                         }
                         case UMP_M2CVM:{

--- a/src/umpProcessor.cpp
+++ b/src/umpProcessor.cpp
@@ -399,7 +399,7 @@ void umpProcessor::processUMP(uint32_t UMP){
 
                 if(mds5Header)mds5Header(
                     group,
-                    (umpMess[1] >> 16) & 0xF,
+                    (umpMess[0] >> 16) & 0xF,
                     umpMess[0] & 0xFFFF,
                     (umpMess[1] >> 16) & 0xFFFF,
                     umpMess[1] & 0xFFFF,
@@ -424,9 +424,9 @@ void umpProcessor::processUMP(uint32_t UMP){
                 sysex[11] =  (umpMess[3] >> 16) & 0xFF;
                 sysex[12] =  (umpMess[3] >> 8) & 0xFF;
                 sysex[13] =  umpMess[3] & 0xFF;
-                if(mds5Header)mds5Payload(
+                if(mds5Payload)mds5Payload(
                     group,
-                    (umpMess[1] >> 16) & 0xF,
+                    (umpMess[0] >> 16) & 0xF,
                     sysex, 14
                     );
             }else {

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -487,6 +487,64 @@ int main(){
     passFail(rtMetSub2, 3);
     printf(" FlexMetronome roundtrip\n");
 
+    //***** MDS Roundtrip (create -> processUMP -> callback) *******************
+    printf("MDS Roundtrip \n");
+    umpProcessor mdsProc;
+
+    // Capture slots
+    uint8_t  mdsH_mds = 255, mdsH_group = 255;
+    uint16_t mdsH_numBytes = 0, mdsH_totalChunks = 0, mdsH_chunkNo = 0;
+    uint16_t mdsH_manu = 0, mdsH_dev = 0, mdsH_sub1 = 0, mdsH_sub2 = 0;
+    mdsProc.setMDSHeaderNotify([&](uint8_t group, uint8_t mds, uint16_t numBytes,
+        uint16_t totalChunks, uint16_t chunkNo, uint16_t manu, uint16_t dev,
+        uint16_t sub1, uint16_t sub2){
+        mdsH_group = group; mdsH_mds = mds; mdsH_numBytes = numBytes;
+        mdsH_totalChunks = totalChunks; mdsH_chunkNo = chunkNo;
+        mdsH_manu = manu; mdsH_dev = dev; mdsH_sub1 = sub1; mdsH_sub2 = sub2;
+    });
+
+    // Header round-trip: mds id comes from word[0], not totalChunks low nibble
+    auto rtMdsH = UMPMessage::mt5MDSHeader(2, 5, 0x00AB, 0x0031, 0x0007,
+                                           0x1234, 0x5678, 0x9ABC, 0xDEF0);
+    for(int i=0; i<4; i++) mdsProc.processUMP(rtMdsH[i]);
+    passFail(mdsH_mds, 5);
+    passFail(mdsH_group, 2);
+    passFail(mdsH_numBytes, 0x00AB);
+    passFail(mdsH_totalChunks, 0x0031);
+    passFail(mdsH_chunkNo, 0x0007);
+    passFail(mdsH_manu, 0x1234);
+    passFail(mdsH_dev, 0x5678);
+    passFail(mdsH_sub1, 0x9ABC);
+    passFail(mdsH_sub2, 0xDEF0);
+    printf(" MDS Header roundtrip\n");
+
+    // Payload round-trip: both callbacks registered (payload dispatch needs the header pointer set)
+    uint8_t mdsP_mds = 255, mdsP_group = 255, mdsP_len = 0;
+    uint8_t mdsP_data[14] = {0};
+    mdsProc.setMDSPayloadNotify([&](uint8_t group, uint8_t mds, uint8_t* data,
+        uint8_t dataLength){
+        mdsP_group = group; mdsP_mds = mds; mdsP_len = dataLength;
+        for(uint8_t k=0; k<dataLength && k<14; k++) mdsP_data[k] = data[k];
+    });
+    uint8_t payload14[14] = {10,11,12,13,14,15,16,17,18,19,20,21,22,23};
+    auto rtMdsP = UMPMessage::mt5MDSPayload(2, 5, payload14, 14);
+    for(int i=0; i<4; i++) mdsProc.processUMP(rtMdsP[i]);
+    passFail(mdsP_mds, 5);
+    passFail(mdsP_group, 2);
+    passFail(mdsP_len, 14);
+    for(uint8_t k=0; k<14; k++) passFail(mdsP_data[k], payload14[k]);
+    printf(" MDS Payload roundtrip\n");
+
+    // Payload fires with only the payload callback registered
+    umpProcessor mdsProcB;
+    uint8_t only_mds = 255;
+    mdsProcB.setMDSPayloadNotify([&](uint8_t group, uint8_t mds, uint8_t* data,
+        uint8_t dataLength){ (void)group;(void)data;(void)dataLength; only_mds = mds; });
+    auto rtMdsP2 = UMPMessage::mt5MDSPayload(0, 7, payload14, 14);
+    for(int i=0; i<4; i++) mdsProcB.processUMP(rtMdsP2[i]);
+    passFail(only_mds, 7);
+    printf(" MDS Payload guard\n");
+
     //***** MIDI-CI Tests *************
     runMIDICITests();
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -545,6 +545,52 @@ int main(){
     passFail(only_mds, 7);
     printf(" MDS Payload guard\n");
 
+    //***** Running status cancelled by System Common / SysEx **********
+    printf("Running status cancellation \n");
+
+    // RS-1: System Common (SPP, F2) cancels running status.
+    umpToBytestream rc;
+    rc.enableRunningStatus = true;
+    uint8_t rcOut[32]; int rcLen = 0;
+    uint32_t rcCC1 = UMPMessage::mt2CC(0, 0, 7, 0);       // B0 07 00
+    uint32_t rcSPP = UMPMessage::mt1SPP(0, 100);          // F2 64 00
+    uint32_t rcCC2 = UMPMessage::mt2CC(0, 0, 7, 0);       // must re-emit B0
+    rc.UMPStreamParse(rcCC1); while(rc.availableBS()) rcOut[rcLen++]=rc.readBS();
+    rc.UMPStreamParse(rcSPP); while(rc.availableBS()) rcOut[rcLen++]=rc.readBS();
+    rc.UMPStreamParse(rcCC2); while(rc.availableBS()) rcOut[rcLen++]=rc.readBS();
+    passFail(rcLen, 9);          // 3 + 3 + 3 (status re-emitted after F2)
+    passFail(rcOut[6], 0xB0);
+    printf(" RS-1 System Common cancels running status\n");
+
+    // RS-2: System Exclusive cancels running status.
+    umpToBytestream rx;
+    rx.enableRunningStatus = true;
+    uint8_t rxOut[32]; int rxLen = 0;
+    uint32_t rxCC1 = UMPMessage::mt2CC(0, 0, 7, 0);       // B0 07 00
+    auto rxSx = UMPMessage::mt3Sysex7(0, 0, 2, {0xAA,0xBB,0,0,0,0}); // F0 2A 3B F7
+    uint32_t rxCC2 = UMPMessage::mt2CC(0, 0, 7, 0);       // must re-emit B0
+    rx.UMPStreamParse(rxCC1); while(rx.availableBS()) rxOut[rxLen++]=rx.readBS();
+    for(int i=0;i<2;i++){ rx.UMPStreamParse(rxSx[i]); while(rx.availableBS()) rxOut[rxLen++]=rx.readBS(); }
+    rx.UMPStreamParse(rxCC2); while(rx.availableBS()) rxOut[rxLen++]=rx.readBS();
+    passFail(rxLen, 10);         // 3 + 4 + 3 (status re-emitted after SysEx)
+    passFail(rxOut[7], 0xB0);
+    printf(" RS-2 SysEx cancels running status\n");
+
+    // RS-3: Real Time (F8 clock) does NOT cancel running status (regression guard).
+    umpToBytestream rt;
+    rt.enableRunningStatus = true;
+    uint8_t rtOut[32]; int rtLen = 0;
+    uint32_t rtCC1 = UMPMessage::mt2CC(0, 0, 7, 0);       // B0 07 00
+    uint32_t rtClk = UMPMessage::mt1TimingClock(0);       // F8 (real time)
+    uint32_t rtCC2 = UMPMessage::mt2CC(0, 0, 7, 0);       // status stays elided
+    rt.UMPStreamParse(rtCC1); while(rt.availableBS()) rtOut[rtLen++]=rt.readBS();
+    rt.UMPStreamParse(rtClk); while(rt.availableBS()) rtOut[rtLen++]=rt.readBS();
+    rt.UMPStreamParse(rtCC2); while(rt.availableBS()) rtOut[rtLen++]=rt.readBS();
+    passFail(rtLen, 6);          // 3 + 1 + 2 (status elided, real time did not cancel)
+    passFail(rtOut[3], 0xF8);
+    passFail(rtOut[4], 0x07);    // no status byte: running status preserved
+    printf(" RS-3 Real Time preserves running status\n");
+
     //***** MIDI-CI Tests *************
     runMIDICITests();
 


### PR DESCRIPTION
Three fixes in the translation layer, each with a test. Independent commits.

1. MDS decode (`umpProcessor`): the MDS ID is read from `word[1]` instead of `word[0]`, in both Header and Payload. The Payload call is also guarded by the Header pointer (`if(mds5Header)mds5Payload`), so it never fires on its own.

2. Cross-group (N)RPN (`umpToBytestream`, Ref #30): the cache is keyed by channel only. A cheap fix for #30: instead of per-Group arrays, reset the cache when the Group changes (1 byte). Single-group and `setFilterGroup` output stays identical. If you'd rather just document it, leave this commit out.

3. Running status (`umpToBytestream`): it wasn't cancelled after System Common or SysEx. Fixed, preserving Real Time.

I tested each fix by reproducing the bug before the change and checking the byte output after; full suite green. @starfishmod
